### PR TITLE
Add options to set the fft size and to normalize the ifft output; calculate the fft by default; and improve the documentation and the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ let
   signal = (0..1023).mapIt(complex64(sin(TAU * 0.1 * float64(it))))
 
   # abs gets us back into real space
-  # false for forward FFT, true for inverse (TODO flip it? separate names?)
-  frequencies = fft(signal, false).mapIt(abs(it))
-  # Scaling must be applied manually
-  signalAgain = fft(fft(signal, false), true).mapIt(abs(it)/signal.len.float64)
+  frequencies = fft(signal).mapIt(abs(it))
+  # backwards scaling is applied automatically to the ifft operation
+  signal_again = ifft(fft(signal))
+
+  # ortho and forward scaling are also supported
+  ortho_norm_frequencies = fft(signal, norm=ortho).mapIt(abs(it))
+  forward_norm_frequencies = fft(signal, norm=forward).mapIt(abs(it))
+  # scaling can also be disabled entirely
+  signal_again_no_norm = ifft(fft(signal, norm=disabled), norm=disabled)
+
+  # it is also possible to explicitly set the fft size to a different value
+  twice_the_frequencies = fft(signal, n=2048).mapIt(abs(it))
 ```
 
 For performance, it's important to compile the application with [LTO](https://en.wikipedia.org/wiki/Interprocedural_optimization#WPO_and_LTO) enabled so that the `complex` module gets inlined properly - see [nim.cfg](./nim.cfg) for an example of how to do this.

--- a/src/fftr.nim
+++ b/src/fftr.nim
@@ -323,7 +323,7 @@ func process*(
 
   transpose(ctx.scratch, output, width, height)
 
-func dft*(input: openArray[Complex64], inverse: bool, normalize: bool = false): seq[Complex64] =
+func dft*(input: openArray[Complex64], inverse: bool = false, normalize: bool = false): seq[Complex64] =
   # Slow DFT - useful for testing
   result.setLen(input.len)
 
@@ -337,7 +337,7 @@ func dft*(input: openArray[Complex64], inverse: bool, normalize: bool = false): 
     for i in 0..<result.len:
       result[i] = result[i] / complexInputLen
 
-func fft*(input: openArray[Complex64], inverse: bool, normalize: bool = false): seq[Complex64] =
+func fft*(input: openArray[Complex64], inverse: bool = false, normalize: bool = false): seq[Complex64] =
   ## Calculates the FFT or the IFFT of an input signal using the best method given the input length
   ##
   ## Inputs:

--- a/src/fftr.nim
+++ b/src/fftr.nim
@@ -333,7 +333,11 @@ func dft*(input: openArray[Complex64], inverse: bool): seq[Complex64] =
       result[k] += input[n] * twiddles[k * n mod twiddles.len]
 
 func fft*(input: openArray[Complex64], inverse: bool): seq[Complex64] =
-  # Convenience entry point that chooses FFT based on input length
+  ## Calculates the FFT or the IFFT of an input signal using the best method given the input length
+  ##
+  ## Inputs:
+  ## - input: The input signal
+  ## - inverse: if true, calculates the inverse FFT, otherwise calculates the FFT
   result.setLen(input.len)
 
   if isPowerOfTwo(input.len):

--- a/src/fftr.nim
+++ b/src/fftr.nim
@@ -323,7 +323,7 @@ func process*(
 
   transpose(ctx.scratch, output, width, height)
 
-func dft*(input: openArray[Complex64], inverse: bool): seq[Complex64] =
+func dft*(input: openArray[Complex64], inverse: bool, normalize: bool = false): seq[Complex64] =
   # Slow DFT - useful for testing
   result.setLen(input.len)
 
@@ -332,12 +332,18 @@ func dft*(input: openArray[Complex64], inverse: bool): seq[Complex64] =
     for n in 0..<result.len:
       result[k] += input[n] * twiddles[k * n mod twiddles.len]
 
-func fft*(input: openArray[Complex64], inverse: bool): seq[Complex64] =
+  if inverse and normalize:
+    let complexInputLen = complex64(float64(input.len))
+    for i in 0..<result.len:
+      result[i] = result[i] / complexInputLen
+
+func fft*(input: openArray[Complex64], inverse: bool, normalize: bool = false): seq[Complex64] =
   ## Calculates the FFT or the IFFT of an input signal using the best method given the input length
   ##
   ## Inputs:
   ## - input: The input signal
   ## - inverse: if true, calculates the inverse FFT, otherwise calculates the FFT
+  ## - normalize: if true, normalizes the results by dividing by the length of the signal when inverse is true
   result.setLen(input.len)
 
   if isPowerOfTwo(input.len):
@@ -349,3 +355,8 @@ func fft*(input: openArray[Complex64], inverse: bool): seq[Complex64] =
   else:
     var ctx = RadixMixed.init(input.len, inverse)
     process(ctx, input, result)
+
+  if inverse and normalize:
+    let complexInputLen = complex64(float64(input.len))
+    for i in 0..<result.len:
+      result[i] = result[i] / complexInputLen

--- a/src/fftr.nim
+++ b/src/fftr.nim
@@ -351,7 +351,7 @@ func dftImpl(input: openArray[Complex64], inverse: bool = false, norm: FftNormal
   for i in 0..<result.len:
     result[i] = result[i] / scalingFactor
 
-func dft*(input: openArray[Complex64], inverse: bool = false, norm: FftNormalization = backward, n = 0): seq[Complex64] =
+func dft*(input: openArray[Complex64], inverse: bool = false, n = 0, norm: FftNormalization = backward): seq[Complex64] =
   ## Calculates the DFT or the IDFT of an input signal using a slow, straight-forward implementation
   ##
   ## This function is only meant for testing, since it is a straight-forward but slow implementaiton of the DFT
@@ -359,6 +359,10 @@ func dft*(input: openArray[Complex64], inverse: bool = false, norm: FftNormaliza
   ## Inputs:
   ## - input: The input signal.
   ## - inverse: If true, calculates the inverse FFT, otherwise calculates the FFT (which is the default).
+  ## - n: Length of the the output.
+  ##      If `n` is not given, the length of the input is automatically used.
+  ##      If `n` is smaller than the length of the input, the input is cropped.
+  ##      If `n` is larger, the input is padded with zeros.
   ## - norm: Normalization mode. Default is `backward`.
   ##         For norm=`backward` no normalization is applied to the FFT
   ##         (i.e. to the forward transform) and scaling by `1/n` is applied to the IFFT
@@ -366,10 +370,6 @@ func dft*(input: openArray[Complex64], inverse: bool = false, norm: FftNormaliza
   ##         For norm=`forward` a `1/n` factor is only applied to the FFT (i.e. to the forward tranform).
   ##         For norm=`ortho`, both transforms are scaled by `1/sqrt(n)`.
   ##         For norm=`disabled`, no normalization is applied to any transform.
-  ## - n: Length of the the output.
-  ##      If `n` is not given, the length of the input is automatically used.
-  ##      If `n` is smaller than the length of the input, the input is cropped.
-  ##      If `n` is larger, the input is padded with zeros.
   let size = if n <= 0: input.len else: n
 
   if size > input.len:
@@ -419,7 +419,7 @@ func fftImpl(input: openArray[Complex64], inverse: bool = false, norm: FftNormal
   for i in 0..<result.len:
     result[i] = result[i] / scalingFactor
 
-func fft*(input: openArray[Complex64], inverse: bool = false, norm: FftNormalization = backward, n = 0): seq[Complex64] =
+func fft*(input: openArray[Complex64], inverse: bool = false, n = 0, norm: FftNormalization = backward): seq[Complex64] =
   ## Calculates the FFT or the IFFT of an input signal
   ##
   ## This function automatically selects the best calculation method given the desired FFT size
@@ -427,6 +427,10 @@ func fft*(input: openArray[Complex64], inverse: bool = false, norm: FftNormaliza
   ## Inputs:
   ## - input: The input signal.
   ## - inverse: If true, calculates the inverse FFT, otherwise calculates the FFT (which is the default).
+  ## - n: Length of the the output.
+  ##      If `n` is not given, the length of the input is automatically used.
+  ##      If `n` is smaller than the length of the input, the input is cropped.
+  ##      If `n` is larger, the input is padded with zeros.
   ## - norm: Normalization mode. Default is `backward`.
   ##         For norm=`backward` no normalization is applied to the FFT
   ##         (i.e. to the forward transform) and scaling by `1/n` is applied to the IFFT
@@ -434,10 +438,6 @@ func fft*(input: openArray[Complex64], inverse: bool = false, norm: FftNormaliza
   ##         For norm=`forward` a `1/n` factor is only applied to the FFT (i.e. to the forward tranform).
   ##         For norm=`ortho`, both transforms are scaled by `1/sqrt(n)`.
   ##         For norm=`disabled`, no normalization is applied to any transform.
-  ## - n: Length of the the output.
-  ##      If `n` is not given, the length of the input is automatically used.
-  ##      If `n` is smaller than the length of the input, the input is cropped.
-  ##      If `n` is larger, the input is padded with zeros.
   let size = if n <= 0: input.len else: n
 
   if size > input.len:
@@ -458,6 +458,10 @@ func ifft*(input: openArray[Complex64], n = 0, norm: FftNormalization = backward
   ## 
   ## Inputs:
   ## - input: The input signal.
+  ## - n: Length of the the output.
+  ##      If `n` is not given, the length of the input is automatically used.
+  ##      If `n` is smaller than the length of the input, the input is cropped.
+  ##      If `n` is larger, the input is padded with zeros.
   ## - norm: Normalization mode. Default is `backward`.
   ##         For norm=`backward` no normalization is applied to the FFT
   ##         (i.e. to the forward transform) and scaling by `1/n` is applied to the IFFT
@@ -465,8 +469,4 @@ func ifft*(input: openArray[Complex64], n = 0, norm: FftNormalization = backward
   ##         For norm=`forward` a `1/n` factor is only applied to the FFT (i.e. to the forward tranform).
   ##         For norm=`ortho`, both transforms are scaled by `1/sqrt(n)`.
   ##         For norm=`disabled`, no normalization is applied to any transform.
-  ## - n: Length of the the output.
-  ##      If `n` is not given, the length of the input is automatically used.
-  ##      If `n` is smaller than the length of the input, the input is cropped.
-  ##      If `n` is larger, the input is padded with zeros.
-  fft(input, inverse=true, norm=norm, n=n)
+  fft(input, inverse=true, n=n, norm=norm)

--- a/src/fftr.nim
+++ b/src/fftr.nim
@@ -13,7 +13,7 @@
 ## ```
 
 import
-  std/[bitops, complex, math, sequtils]
+  std/[bitops, complex, math]
 
 export complex
 
@@ -352,14 +352,16 @@ func dft*(input: openArray[Complex64], inverse: bool = false, normalize: bool = 
   ##      If `n` is larger, the input is padded with zeros.
   let size = if n <= 0: input.len else: n
 
-  if size < input.len:
+  if size > input.len:
     # Extend the input with zeros as much as needed
-    let input = input.toSeq & newSeq[Complex64](size - input.len)
+    var extendedInput = newSeq[Complex64](size)
+    extendedInput[0..input.high] = input
+    dftImpl(extendedInput, inverse=inverse, normalize=normalize)
   elif size < input.len:
     # Crop the input as much as needed
-    let input = input[0..<size]
-
-  dftImpl(input, inverse=inverse, normalize=normalize)
+    dftImpl(input[0..<size], inverse=inverse, normalize=normalize)
+  else:
+    dftImpl(input, inverse=inverse, normalize=normalize)
 
 func fftImpl(input: openArray[Complex64], inverse: bool = false, normalize: bool = false): seq[Complex64] =
   ## Calculates the FFT or the IFFT of an input signal using the best method given the input length
@@ -401,16 +403,16 @@ func fft*(input: openArray[Complex64], inverse: bool = false, normalize: bool = 
   ##      If `n` is larger, the input is padded with zeros.
   let size = if n <= 0: input.len else: n
 
-  let input = if size > input.len:
+  if size > input.len:
     # Extend the input with zeros as much as needed
-    input.toSeq & newSeq[Complex64](size - input.len)
+    var extendedInput = newSeq[Complex64](size)
+    extendedInput[0..input.high] = input
+    fftImpl(extendedInput, inverse=inverse, normalize=normalize)
   elif size < input.len:
     # Crop the input as much as needed
-    input[0..<size]
+    fftImpl(input[0..<size], inverse=inverse, normalize=normalize)
   else:
-    input.toSeq
-
-  fftImpl(input, inverse=inverse, normalize=normalize)
+    fftImpl(input, inverse=inverse, normalize=normalize)
 
 func ifft*(input: openArray[Complex64], n = 0, normalize: bool = false): seq[Complex64] {.inline.} =
   ## Calculates the IFFT of an input signal using the best method given the input length

--- a/tests/test_fftr.nim
+++ b/tests/test_fftr.nim
@@ -40,6 +40,25 @@ suite "FFT":
         bf.re - af.re < 1e-10
         bf.im - af.im < 1e-10
 
+  test "normalized ifft":
+    let
+      signal = makeBuffer(512)
+      aa = dft(dft(signal, false), true, normalize=true)
+      bb = fft(fft(signal, false), true, normalize=true)
+
+      sf = foldl(signal, a + b, complex64(0.0))
+      af = foldl(aa, a + b, complex64(0.0))
+      bf = foldl(bb, a + b, complex64(0.0))
+    checkpoint($(aa))
+    checkpoint($(bb))
+    checkpoint($(af))
+    checkpoint($(bf))
+    check:
+      abs(bf.re - af.re) < 1e-10
+      abs(bf.im - af.im) < 1e-10
+      abs(sf.re - bf.re) < 1e-10
+      abs(sf.im - bf.im) < 1e-10
+
 # These are broken on nim 1.6:
 # static:
 #   for i in [3, 4, 8, 9, 16, 17]:

--- a/tests/test_fftr.nim
+++ b/tests/test_fftr.nim
@@ -21,8 +21,8 @@ suite "FFT":
       checkpoint($(af))
       checkpoint($(bf))
       check:
-        bf.re - af.re < 1e-10
-        bf.im - af.im < 1e-10
+        abs(bf.re - af.re) < 1e-10
+        abs(bf.im - af.im) < 1e-10
 
     test "fft vs dft inverse " & $i:
       let
@@ -37,8 +37,8 @@ suite "FFT":
       checkpoint($(af))
       checkpoint($(bf))
       check:
-        bf.re - af.re < 1e-10
-        bf.im - af.im < 1e-10
+        abs(bf.re - af.re) < 1e-10
+        abs(bf.im - af.im) < 1e-10
 
   test "normalized ifft":
     let

--- a/tests/test_fftr.nim
+++ b/tests/test_fftr.nim
@@ -59,31 +59,41 @@ suite "FFT":
       abs(sf.re - bf.re) < 1e-10
       abs(sf.im - bf.im) < 1e-10
 
-  test "fft with specific size":
+  # Test FFT with a specific sizes
+  for n in [8, 12, 16]:
     let
-      signal = makeBuffer(8)
-      aa = dft(signal, false, n=16)
-      bb = fft(signal, false, n=16)
-      cc = ifft(bb, normalize=true)
+      signalLen = 12
+    let desc = if n > signalLen: "larger than input"
+      elif n < signalLen: "smaller than input"
+      else: "same as input"
+    test "fft with specific size " & desc:
+      let
+        signal = makeBuffer(signalLen)
+        aa = dft(signal, false, n=n)
+        bb = fft(signal, false, n=n)
+        cc = ifft(bb)
 
-      sf = foldl(signal, a + b, complex64(0.0))
-      af = foldl(aa, a + b, complex64(0.0))
-      bf = foldl(bb, a + b, complex64(0.0))
-      cf = foldl(cc, a + b, complex64(0.0))
-    checkpoint($(aa))
-    checkpoint($(bb))
-    checkpoint($(signal))
-    checkpoint($(cc))
-    checkpoint($(sf))
-    checkpoint($(af))
-    checkpoint($(bf))
-    checkpoint($(cf))
-    check:
-      bb.len == 16
-      abs(bf.re - af.re) < 1e-10
-      abs(bf.im - af.im) < 1e-10
-      abs(sf.re - cf.re) < 1e-10
-      abs(sf.im - cf.im) < 1e-10
+        sf = foldl(signal, a + b, complex64(0.0))
+        af = foldl(aa, a + b, complex64(0.0))
+        bf = foldl(bb, a + b, complex64(0.0))
+        cf = foldl(cc, a + b, complex64(0.0))
+      checkpoint($(aa))
+      checkpoint($(bb))
+      checkpoint($(signal))
+      checkpoint($(cc))
+      checkpoint($(sf))
+      checkpoint($(af))
+      checkpoint($(bf))
+      checkpoint($(cf))
+      check:
+        bb.len == n
+        abs(bf.re - af.re) < 1e-10
+        abs(bf.im - af.im) < 1e-10
+      # When n is smaller than the input, the IFFT of the FFT does not match the input
+      if n >= signalLen:
+        check:
+          abs(sf.re - cf.re) < 1e-10
+          abs(sf.im - cf.im) < 1e-10
 
   test "ifft convenience function":
     let

--- a/tests/test_fftr.nim
+++ b/tests/test_fftr.nim
@@ -59,6 +59,49 @@ suite "FFT":
       abs(sf.re - bf.re) < 1e-10
       abs(sf.im - bf.im) < 1e-10
 
+  test "fft with specific size":
+    let
+      signal = makeBuffer(8)
+      aa = dft(signal, false, n=16)
+      bb = fft(signal, false, n=16)
+      cc = ifft(bb, normalize=true)
+
+      sf = foldl(signal, a + b, complex64(0.0))
+      af = foldl(aa, a + b, complex64(0.0))
+      bf = foldl(bb, a + b, complex64(0.0))
+      cf = foldl(cc, a + b, complex64(0.0))
+    checkpoint($(aa))
+    checkpoint($(bb))
+    checkpoint($(signal))
+    checkpoint($(cc))
+    checkpoint($(sf))
+    checkpoint($(af))
+    checkpoint($(bf))
+    checkpoint($(cf))
+    check:
+      bb.len == 16
+      abs(bf.re - af.re) < 1e-10
+      abs(bf.im - af.im) < 1e-10
+      abs(sf.re - cf.re) < 1e-10
+      abs(sf.im - cf.im) < 1e-10
+
+  test "ifft convenience function":
+    let
+      signal = makeBuffer(512)
+      aa = fft(signal, false)
+      bb = ifft(signal)
+
+      af = foldl(aa, a + b, complex64(0.0))
+      bf = foldl(bb, a + b, complex64(0.0))
+    checkpoint($(aa))
+    checkpoint($(bb))
+    checkpoint($(af))
+    checkpoint($(bf))
+    check:
+      abs(bf.re - af.re) < 1e-10
+      abs(bf.im - af.im) < 1e-10
+
+
 # These are broken on nim 1.6:
 # static:
 #   for i in [3, 4, 8, 9, 16, 17]:


### PR DESCRIPTION
This PR does a few small things:
- It improves the fft function documentation
- It adds a normalize argument to the fft and dft functions. Normalization is disabled by default but if enabled it will normalize the ifft otuput (i.e. it only applies if inverse is true)
- It makes inverse=false the default (i.e. the fft function calculates the fft by default)
- It adds an `n` argument to make it possible to choose the FFT size (it still uses the input length by default).
- It improves the tests (which could fail if the folds were negative)
